### PR TITLE
Remove default icon url

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,12 @@ Clearbit.key = ENV['CLEARBIT_KEY']
 Clearbit::Slack.configure do |config|
   config.slack_url = ENV['SLACK_URL']
   config.slack_channel = '#test'
-  config.default_icon_url = 'https://placekitten.com/g/75/75'
 end
 ```
 
 #### Clearbit Key
 
 Sign up for a [Free Trail](https://clearbit.com/) if you don't already have a Clearbit key.
-
-#### Default Icon URL
-
-The `default_icon_url` will be used when `person.avatar` is blank.
 
 ![screen shot 2015-06-15 at 7 34 48 pm](https://cloud.githubusercontent.com/assets/739782/8174770/ba4ad806-1395-11e5-9298-6f7479f1cdfb.png)
 

--- a/lib/clearbit/slack.rb
+++ b/lib/clearbit/slack.rb
@@ -21,10 +21,6 @@ module Clearbit
       configuration.slack_channel || raise('Config Error: No slack_channel provided')
     end
 
-    def self.default_icon_url
-      configuration.default_icon_url || ''
-    end
-
     def self.configure
       yield configuration if block_given?
     end

--- a/lib/clearbit/slack/configuration.rb
+++ b/lib/clearbit/slack/configuration.rb
@@ -1,7 +1,7 @@
 module Clearbit
   module Slack
     class Configuration
-      attr_accessor :slack_url, :slack_channel, :default_icon_url
+      attr_accessor :slack_url, :slack_channel
     end
   end
 end

--- a/lib/clearbit/slack/notifier.rb
+++ b/lib/clearbit/slack/notifier.rb
@@ -33,7 +33,7 @@ module Clearbit
       private
 
       def icon_url
-        person && person.avatar || Slack.default_icon_url
+        person && person.avatar || ''
       end
 
       def username


### PR DESCRIPTION
Slack already supports uploading a customer icon through their web
interface. No need to duplicate that functionality.
