### PR TITLE
Surface user email into Person attachment

### DIFF
--- a/clearbit-slack.gemspec
+++ b/clearbit-slack.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'maccman-mash'
   spec.add_dependency 'slack-notifier', '~> 1.2.1'
   spec.add_development_dependency 'bundler', '~> 1.9'
-  spec.add_development_dependency 'hashie', '~> 3.4.2'
   spec.add_development_dependency 'pry', '~> 0.10.1'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/lib/clearbit/slack.rb
+++ b/lib/clearbit/slack.rb
@@ -1,4 +1,5 @@
 require 'slack-notifier'
+require 'mash'
 
 require 'clearbit/slack/configuration'
 require 'clearbit/slack/helpers'

--- a/lib/clearbit/slack/attachments/person.rb
+++ b/lib/clearbit/slack/attachments/person.rb
@@ -44,12 +44,12 @@ module Clearbit
         end
 
         def employment
-          return unless person.employment.name
+          return unless person.employment && person.employment.name
           field 'Employment', person.employment.name
         end
 
         def position
-          return unless person.employment.title
+          return unless person.employment && person.employment.title
           field 'Position', person.employment.title
         end
 

--- a/lib/clearbit/slack/helpers.rb
+++ b/lib/clearbit/slack/helpers.rb
@@ -23,7 +23,7 @@ module Clearbit
       end
 
       def aboutme(aboutme)
-        return unless aboutme.handle
+        return unless aboutme && aboutme.handle
         value = link(
           "https://about.me/#{aboutme.handle}",
           aboutme.handle
@@ -32,7 +32,7 @@ module Clearbit
       end
 
       def angellist(angellist)
-        return unless angellist.handle
+        return unless angellist && angellist.handle
         value = link(
           "https://angel.co/#{angellist.handle}",
           angellist.handle,
@@ -42,7 +42,7 @@ module Clearbit
       end
 
       def github(github)
-        return unless github.handle
+        return unless github && github.handle
         value = link(
           "https://github.com/#{github.handle}",
           github.handle,
@@ -52,7 +52,7 @@ module Clearbit
       end
 
       def facebook(facebook)
-        return unless facebook.handle
+        return unless facebook && facebook.handle
         value = link(
           "https://www.facebook.com/#{facebook.handle}",
           facebook.handle
@@ -61,7 +61,7 @@ module Clearbit
       end
 
       def twitter(twitter)
-        return unless twitter.handle
+        return unless twitter && twitter.handle
         value = link(
           "http://twitter.com/#{twitter.handle}",
           "@#{twitter.handle}",
@@ -71,7 +71,7 @@ module Clearbit
       end
 
       def linkedin(linkedin)
-        return unless linkedin.handle
+        return unless linkedin && linkedin.handle
         value = link(
           "https://www.linkedin.com/#{linkedin.handle}",
           linkedin.handle

--- a/spec/clearbit/slack/attachments/company_spec.rb
+++ b/spec/clearbit/slack/attachments/company_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Clearbit::Slack::Attachments::Company, '#as_json' do
   it 'returns a company attachment' do
     company_data = parsed_fixture_data 'company.json'
-    company = Hashie::Mash.new(company_data)
+    company = Mash.new(company_data)
 
     result = Clearbit::Slack::Attachments::Company.new(company).as_json
 

--- a/spec/clearbit/slack/attachments/person_spec.rb
+++ b/spec/clearbit/slack/attachments/person_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Clearbit::Slack::Attachments::Person, '#as_json' do
   it 'returns a person attachment' do
     person_data = parsed_fixture_data 'person.json'
-    person = Hashie::Mash.new(person_data)
+    person = Mash.new(person_data)
 
     result = Clearbit::Slack::Attachments::Person.new(person).as_json
 

--- a/spec/clearbit/slack/notifier_spec.rb
+++ b/spec/clearbit/slack/notifier_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Clearbit::Slack::Notifier do
+  context 'person data not found' do
+    it 'returns "Unknown" for username' do
+      person = Mash.new(name: {})
+      notifier = double(ping: true)
+      allow(Slack::Notifier).to receive(:new).and_return(notifier)
+
+      Clearbit::Slack::Notifier.new(person: person).ping
+
+      expect(Slack::Notifier).to have_received(:new).with(
+        'http://example', channel: '#test', icon_url: '', username: 'Unknown'
+      )
+      expect(notifier).to have_received(:ping)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,13 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'clearbit/slack'
 require 'pry'
-require 'hashie'
 
 Dir[File.expand_path('spec/support/**/*.rb')].each { |file| require file }
+
+Clearbit::Slack.configure do |config|
+  config.slack_url = 'http://example'
+  config.slack_channel = '#test'
+end
 
 RSpec.configure do |config|
   include Spec::Support::Helpers


### PR DESCRIPTION
When a Person isn't found on Clearbit the email will show up as blank in
the person attachment. Using a NullPerson will allow a minimal person so
we pass that directly into the notifier.
