### PR TITLE
Require Clearbit Gem as part of package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Clean beautiful customer data. Now in Slack.
 Add to your application's Gemfile:
 
 ```ruby
-gem 'clearbit'
 gem 'clearbit-slack'
 ```
 
@@ -59,20 +58,16 @@ module APIHub
         customer = Customer.find!(customer_id)
         response = Clearbit::Streaming::PersonCompany[email: customer.email]
 
-        if response.person || response.company
-          params = {
-            company: response.company,
-            email: customer.email,
-            family_name: customer.last_name,
-            given_name: customer.first_name,
-            message: "View details in <https://admin-panel.com/#{customer.token}|Admin Panel>",
-            person: response.person
-          }
+        response.merge!(
+          email: customer.email,
+          family_name: customer.last_name,
+          given_name: customer.first_name,
+          message: "View details in <https://admin-panel.com/#{customer.token}|Admin Panel>",
+        )
 
-          Clearbit::Slack.ping(params)
-        end
+        Clearbit::Slack.ping(response)
 
-        # Persist Clearbit Data
+        # Persist the Clearbit Data
       end
     end
   end
@@ -89,21 +84,18 @@ class WebhooksController < ApplicationController
   def clearbit
     webhook = Clearbit::Webhook.new(env)
     customer = Customer.find!(webhook.webhook_id)
+    response =  webhook.body
 
-    if webhook.body.person || webhook.body.company
-      params = {
-        company: webhook.body.company,
-        email: customer.email,
-        family_name: customer.last_name,
-        given_name: customer.first_name,
-        message: "View details in <https://admin-panel/#{webhook.webhook_id}|Admin Panel>",
-        person: webhook.body.person
-      }
+    response.merge!(
+      email: customer.email,
+      family_name: customer.last_name,
+      given_name: customer.first_name,
+      message: "View details in <https://admin-panel.com/#{customer.token}|Admin Panel>",
+    )
 
-      Clearbit::Slack.ping(params)
-    end
+    Clearbit::Slack.ping(response)
 
-    # Persist Clearbit Data
+    # Persist the Clearbit Data
   end
 end
 ```

--- a/clearbit-slack.gemspec
+++ b/clearbit-slack.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'clearbit', '~> 0.1.6'
   spec.add_dependency 'maccman-mash', '~> 0.0.2'
   spec.add_dependency 'slack-notifier', '~> 1.2.1'
   spec.add_development_dependency 'bundler', '~> 1.9'

--- a/lib/clearbit/slack.rb
+++ b/lib/clearbit/slack.rb
@@ -1,5 +1,6 @@
-require 'slack-notifier'
+require 'clearbit'
 require 'mash'
+require 'slack-notifier'
 
 require 'clearbit/slack/configuration'
 require 'clearbit/slack/helpers'

--- a/lib/clearbit/slack/version.rb
+++ b/lib/clearbit/slack/version.rb
@@ -1,5 +1,5 @@
 module Clearbit
   module Slack
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end


### PR DESCRIPTION
Having users include 2 Gems could create confusion. By including the
core Clearbit gem we can simplify the usage instructions.

* Include base Clearbit Gem
* Update README to post all messages to Slack