### PR TITLE
Fix hash keys for default name data

### DIFF
--- a/lib/clearbit/slack/notifier.rb
+++ b/lib/clearbit/slack/notifier.rb
@@ -53,8 +53,8 @@ module Clearbit
         Mash.new(
           email: email,
           name: {
-            given: given_name,
-            family: family_name
+            given_name: given_name,
+            family_name: family_name
           }
         )
       end

--- a/lib/clearbit/slack/version.rb
+++ b/lib/clearbit/slack/version.rb
@@ -1,5 +1,5 @@
 module Clearbit
   module Slack
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end

--- a/spec/clearbit/slack/notifier_spec.rb
+++ b/spec/clearbit/slack/notifier_spec.rb
@@ -1,16 +1,55 @@
 require 'spec_helper'
 
 describe Clearbit::Slack::Notifier do
-  context 'person data not found' do
-    it 'returns "Unknown" for username' do
-      person = Mash.new(name: {})
-      notifier = double(ping: true)
-      allow(Slack::Notifier).to receive(:new).and_return(notifier)
+  let(:notifier) { double(ping: true) }
 
-      Clearbit::Slack::Notifier.new(person: person).ping
+  before do
+    allow(Slack::Notifier).to receive(:new).and_return(notifier)
+  end
+
+  context 'default values for given_name and family_name' do
+    it 'returns the default values' do
+      params = {
+        person: nil,
+        given_name: 'Alex',
+        family_name: 'Maccaw',
+        email: 'alex@alexmaccaw.com',
+        message: 'message'
+      }
+
+      Clearbit::Slack::Notifier.new(params).ping
 
       expect(Slack::Notifier).to have_received(:new).with(
-        'http://example', channel: '#test', icon_url: '', username: 'Unknown'
+        'http://example', {
+          channel: '#test',
+          icon_url: '',
+          username: 'Alex Maccaw'
+        }
+      )
+
+      expect(notifier).to have_received(:ping).with('message', attachments: [{
+        color: 'good',
+        fields: [{
+          title: 'Email',
+          value: 'alex@alexmaccaw.com',
+          short: true
+        }]
+      }])
+    end
+  end
+
+  context 'person not found' do
+    it 'returns "Unknown" for username' do
+      params = { person: nil }
+
+      Clearbit::Slack::Notifier.new(params).ping
+
+      expect(Slack::Notifier).to have_received(:new).with(
+        'http://example', {
+          channel: '#test',
+          icon_url: '',
+          username: 'Unknown'
+        }
       )
       expect(notifier).to have_received(:ping)
     end


### PR DESCRIPTION
When a person was unknown the Slack message was from "Unknown"
regardless if a default given/family name was passed in.

* Add spec to verify keys are set correctly