### PR TITLE
Remove AngelList and other low value fields

### DIFF
--- a/lib/clearbit/slack/attachments/company.rb
+++ b/lib/clearbit/slack/attachments/company.rb
@@ -27,26 +27,15 @@ module Clearbit
 
         def fields
           [
-            website,
-            raised,
             location,
+            website,
             type,
+            raised,
             employees,
-            angellist(company.angellist),
-            facebook(company.facebook),
             linkedin(company.linkedin),
             twitter(company.twitter),
+            tech
           ]
-        end
-
-        def type
-          return unless company.type
-          field 'Type', company.type
-        end
-
-        def employees
-          return unless company.employees
-          field 'Employees', format_number(company.employees)
         end
 
         def location
@@ -59,9 +48,24 @@ module Clearbit
           field 'Website', company.url
         end
 
+        def type
+          return unless company.type
+          field 'Type', company.type
+        end
+
+        def employees
+          return unless company.employees
+          field 'Employees', format_number(company.employees)
+        end
+
         def raised
           return unless company.raised
           field 'Raised', "$#{format_number(company.raised)}"
+        end
+
+        def tech
+          return unless company.tech
+          field 'Tech', tech.join(', '), false
         end
       end
     end

--- a/lib/clearbit/slack/attachments/person.rb
+++ b/lib/clearbit/slack/attachments/person.rb
@@ -22,12 +22,11 @@ module Clearbit
           [
             bio,
             email,
-            employment,
-            position,
             location,
-            aboutme(person.aboutme),
-            angellist(person.angellist),
-            facebook(person.facebook),
+            employment,
+            title,
+            role,
+            seniority,
             linkedin(person.linkedin),
             twitter(person.twitter),
           ]
@@ -43,14 +42,24 @@ module Clearbit
           field 'Email', person.email
         end
 
+        def title
+          return unless person.employment && person.employment.title
+          field 'Title', person.employment.title
+        end
+
         def employment
           return unless person.employment && person.employment.name
           field 'Employment', person.employment.name
         end
 
-        def position
-          return unless person.employment && person.employment.title
-          field 'Position', person.employment.title
+        def role
+          return unless person.employment && person.employment.role
+          field 'Role', person.employment.role
+        end
+
+        def seniority
+          return unless person.employment && person.employment.seniority
+          field 'Seniority', person.employment.seniority
         end
 
         def location

--- a/spec/clearbit/slack/attachments/company_spec.rb
+++ b/spec/clearbit/slack/attachments/company_spec.rb
@@ -13,11 +13,10 @@ describe Clearbit::Slack::Attachments::Company, '#as_json' do
       :text=>"We are building a suite of business intelligence APIs to help companies find more information on their customers in order to increase sales and reduce fraud. Our goal is to be the data backbone for modern businesses, powering everything from credit checks to lead scoring.\n\nWe currently provide three APIs:\n\n- Person API: Takes an email address and returns information about a person such as name, avatar, title, and social accounts.\n- Company API: Takes a domain name and returns data about a company, such as name, logo, market category, and headcount.\n- Watchlist API: Lets you search names against a consolidate global watchlist, simplifying OFAC compliance.\n\nOur customers mainly use our APIs for lead-scoring, processing all their incoming leads through both the Person and Company APIs to determine which ones are valuable. This saves sales teams a great deal of time compared to manual lead research and qualification. ",
       :color=>"good",
       :fields=>[
-        {:title=>"Website", :value=>"http://clearbit.com", :short=>true},
         {:title=>"Location", :value=>"601 4th Street #310, San Francisco, CA 94107, USA", :short=>true},
+        {:title=>"Website", :value=>"http://clearbit.com", :short=>true},
         {:title=>"Type", :value=>"private", :short=>true},
         {:title=>"Employees", :value=>"10", :short=>true},
-        {:title=>"AngelList", :value=>"<https://angel.co/clearbit|clearbit> (184 followers)", :short=>true},
         {:title=>"LinkedIn", :value=>"<https://www.linkedin.com/company/clearbit|company/clearbit>", :short=>true},
         {:title=>"Twitter", :value=>"<http://twitter.com/clearbit|clearbit> (271 followers)", :short=>true}
       ]

--- a/spec/clearbit/slack/attachments/person_spec.rb
+++ b/spec/clearbit/slack/attachments/person_spec.rb
@@ -11,16 +11,13 @@ describe Clearbit::Slack::Attachments::Person, '#as_json' do
       :color=>"good",
       :fields=>[
         {:title=>"Bio", :value=>"O'Reilly author, software engineer & traveller. Founder of https://clearbit.com", :short=>false},
-       {:title=>"Email", :value=>"alex@alexmaccaw.com", :short=>true},
-       {:title=>"Employment", :value=>"Clearbit", :short=>true},
-       {:title=>"Position", :value=>"CEO", :short=>true},
-       {:title=>"Location", :value=>"San Francisco, CA, USA", :short=>true},
-       {:title=>"AboutMe", :value=>"<https://about.me/maccaw|maccaw>", :short=>true},
-       {:title=>"AngelList", :value=>"<https://angel.co/maccaw|maccaw> (532 followers)", :short=>true},
-       {:title=>"Facebook", :value=>"<https://www.facebook.com/amaccaw|amaccaw>", :short=>true},
-       {:title=>"LinkedIn", :value=>"<https://www.linkedin.com/pub/alex-maccaw/78/929/ab5|pub/alex-maccaw/78/929/ab5>", :short=>true},
-       {:title=>"Twitter", :value=>"<http://twitter.com/maccaw|maccaw> (15,248 followers)", :short=>true}
+        {:title=>"Email", :value=>"alex@alexmaccaw.com", :short=>true},
+        {:title=>"Location", :value=>"San Francisco, CA, USA", :short=>true},
+        {:title=>"Employment", :value=>"Clearbit", :short=>true},
+        {:title=>"Title", :value=>"CEO", :short=>true},
+        {:title=>"LinkedIn", :value=>"<https://www.linkedin.com/pub/alex-maccaw/78/929/ab5|pub/alex-maccaw/78/929/ab5>", :short=>true},
+        {:title=>"Twitter", :value=>"<http://twitter.com/maccaw|maccaw> (15,248 followers)", :short=>true}
       ]
-    })
+      })
   end
 end


### PR DESCRIPTION
We've stopped indexing AngelList data so profiles have been removed from
our API responses.

* Remove deprecated data from notifer
* Add tech tags as long field at end of company data
* Add person role and seniority 