### PR TITLE
Unknown person requires a bio

### DIFF
--- a/clearbit-slack.gemspec
+++ b/clearbit-slack.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.10', '>= 0.10.1'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.5', '>= 3.5.0'
+  spec.add_development_dependency 'webmock', '~> 2'
 
   spec.add_runtime_dependency 'clearbit', '~> 0.2', '>= 0.2.2'
   spec.add_runtime_dependency 'maccman-mash', '~> 0.0', '>= 0.0.2'

--- a/lib/clearbit/slack/notifier.rb
+++ b/lib/clearbit/slack/notifier.rb
@@ -52,6 +52,7 @@ module Clearbit
       def unknown_person
         Mash.new(
           email: email,
+          bio: 'unknown person',
           name: {
             given_name: given_name,
             family_name: family_name

--- a/spec/clearbit/slack/notifier_spec.rb
+++ b/spec/clearbit/slack/notifier_spec.rb
@@ -30,7 +30,7 @@ describe Clearbit::Slack::Notifier do
         :fallback=>'alex@alexmaccaw.com',
         :author_name=>nil,
         :author_icon=>nil,
-        :text=>nil,
+        :text=>'unknown person',
         :color=>"good",
         fields: [{
           title: 'Email',

--- a/spec/clearbit/slack/notifier_spec.rb
+++ b/spec/clearbit/slack/notifier_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe Clearbit::Slack::Notifier do
-  let(:notifier) { double(ping: true) }
-
-  before do
-    allow(Slack::Notifier).to receive(:new).and_return(notifier)
-  end
-
   context 'default values for given_name and family_name' do
+    let(:notifier) { double(ping: true) }
+
+    before do
+      allow(Slack::Notifier).to receive(:new).and_return(notifier)
+    end
+
     it 'returns the default values' do
       params = {
         person: nil,
@@ -38,6 +38,24 @@ describe Clearbit::Slack::Notifier do
           short: true
         }]
       }])
+    end
+  end
+
+  context 'integration test' do
+    it 'the default values are able to be post to slack' do
+      stub = stub_request(:post, 'example')
+
+      params = {
+        person: nil,
+        given_name: 'Alex',
+        family_name: 'Maccaw',
+        email: 'alex@alexmaccaw.com',
+        message: 'message'
+      }
+
+      Clearbit::Slack::Notifier.new(params).ping
+
+      expect(stub).to have_been_requested
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
+require 'webmock/rspec'
 require 'clearbit/slack'
 require 'pry'
 


### PR DESCRIPTION
With the update to the latest `slack-notifier`, posting to slack is broken when we try to send information about someone that clearbit was unable to resolve. 

I have added an integration test that confirms this breaking behavior and fix it by providing a dummy bio.