### PR TITLE
family_name and given_name are unused when provided as defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ Sign up for a [Free Trial](https://clearbit.com/) if you don't already have a Cl
 | person      | Person data returned form Clearbit                 |
 | message     | Used for deep link into an internal Admin/CRM      |
 | email       | Used to augment message data when Person not found |
-| given_name  | Used to augment message data when Person not found |
-| family_name | Used to augment message data when Person not found |
+| full_name   | Used to augment message data when Person not found |
 
 ### Streaming API
 
@@ -60,8 +59,7 @@ module APIHub
 
         result.merge!(
           email: customer.email,
-          family_name: customer.last_name,
-          given_name: customer.first_name,
+          full_name: "#{customer.last_name} #{customer.first_name}",
           message: "View details in <https://admin-panel.com/#{customer.token}|Admin Panel>",
         )
 
@@ -88,8 +86,7 @@ class WebhooksController < ApplicationController
 
     result.merge!(
       email: customer.email,
-      family_name: customer.last_name,
-      given_name: customer.first_name,
+      full_name: "#{customer.last_name} #{customer.first_name}",
       message: "View details in <https://admin-panel.com/#{customer.token}|Admin Panel>",
     )
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ module APIHub
 
         result.merge!(
           email: customer.email,
-          full_name: "#{customer.last_name} #{customer.first_name}",
+          full_name: "#{customer.first_name} #{customer.last_name}",
           message: "View details in <https://admin-panel.com/#{customer.token}|Admin Panel>",
         )
 
@@ -86,7 +86,7 @@ class WebhooksController < ApplicationController
 
     result.merge!(
       email: customer.email,
-      full_name: "#{customer.last_name} #{customer.first_name}",
+      full_name: "#{customer.first_name} #{customer.last_name}",
       message: "View details in <https://admin-panel.com/#{customer.token}|Admin Panel>",
     )
 

--- a/lib/clearbit/slack/notifier.rb
+++ b/lib/clearbit/slack/notifier.rb
@@ -2,7 +2,7 @@ module Clearbit
   module Slack
     class Notifier
       attr_reader :company, :message, :person,
-                  :given_name, :family_name, :email,
+                  :full_name, :email,
                   :slack_url, :slack_channel, :slack_icon
 
       def initialize(attrs = {}, options = {})
@@ -11,8 +11,7 @@ module Clearbit
         @company       = attrs[:company]
         @message       = attrs[:message]
         @person        = attrs[:person]
-        @given_name    = attrs[:given_name]
-        @family_name   = attrs[:family_name]
+        @full_name     = attrs[:full_name]
         @email         = attrs[:email]
         @slack_url     = options[:slack_url]
         @slack_channel = options[:slack_channel]
@@ -54,8 +53,7 @@ module Clearbit
           email: email,
           bio: 'unknown person',
           name: {
-            given_name: given_name,
-            family_name: family_name
+            full_name: full_name,
           }
         )
       end

--- a/spec/clearbit/slack/notifier_spec.rb
+++ b/spec/clearbit/slack/notifier_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 describe Clearbit::Slack::Notifier do
+
+  let(:params) do
+    {
+      person: nil,
+      full_name: 'Alex Maccaw',
+      email: 'alex@alexmaccaw.com',
+      message: 'message'
+    }
+  end
+
   context 'default values for given_name and family_name' do
     let(:notifier) { double(ping: true) }
 
@@ -9,13 +19,6 @@ describe Clearbit::Slack::Notifier do
     end
 
     it 'returns the default values' do
-      params = {
-        person: nil,
-        full_name: 'Alex Maccaw',
-        email: 'alex@alexmaccaw.com',
-        message: 'message'
-      }
-
       Clearbit::Slack::Notifier.new(params).ping
 
       expect(Slack::Notifier).to have_received(:new).with(
@@ -43,14 +46,6 @@ describe Clearbit::Slack::Notifier do
   context 'integration test' do
     it 'the default values are able to be post to slack' do
       stub = stub_request(:post, 'example')
-
-      params = {
-        person: nil,
-        given_name: 'Alex',
-        family_name: 'Maccaw',
-        email: 'alex@alexmaccaw.com',
-        message: 'message'
-      }
 
       Clearbit::Slack::Notifier.new(params).ping
 

--- a/spec/clearbit/slack/notifier_spec.rb
+++ b/spec/clearbit/slack/notifier_spec.rb
@@ -11,8 +11,7 @@ describe Clearbit::Slack::Notifier do
     it 'returns the default values' do
       params = {
         person: nil,
-        given_name: 'Alex',
-        family_name: 'Maccaw',
+        full_name: 'Alex Maccaw',
         email: 'alex@alexmaccaw.com',
         message: 'message'
       }
@@ -27,14 +26,14 @@ describe Clearbit::Slack::Notifier do
       )
 
       expect(notifier).to have_received(:ping).with('message', attachments: [{
-        :fallback=>'alex@alexmaccaw.com',
-        :author_name=>nil,
+        :fallback=>'alex@alexmaccaw.com - Alex Maccaw',
+        :author_name=>'Alex Maccaw',
         :author_icon=>nil,
         :text=>'unknown person',
         :color=>"good",
         fields: [{
           title: 'Email',
-          value: 'alex@alexmaccaw.com',
+          value: 'alex@alexmaccaw.com - Alex Maccaw',
           short: true
         }]
       }])


### PR DESCRIPTION
It seems that only full_name is sent through to slack so it seems like there is no point in populating `given_name` and `family_name` as suggested in the readme. This allows people to provide `full_name` instead which is sent through to slack