### PR TITLE
Provide a fallback when bio is not provided

### DIFF
--- a/lib/clearbit/slack/attachments/person.rb
+++ b/lib/clearbit/slack/attachments/person.rb
@@ -14,7 +14,7 @@ module Clearbit
             fallback: fallback,
             author_name: person.name.full_name,
             author_icon: person.avatar,
-            text: person.bio || fallback,
+            text: person.bio.to_s,
             color: color,
             fields: fields.compact
           }

--- a/lib/clearbit/slack/attachments/person.rb
+++ b/lib/clearbit/slack/attachments/person.rb
@@ -14,7 +14,7 @@ module Clearbit
             fallback: fallback,
             author_name: person.name.full_name,
             author_icon: person.avatar,
-            text: person.bio,
+            text: person.bio || fallback,
             color: color,
             fields: fields.compact
           }

--- a/spec/clearbit/slack/attachments/person_spec.rb
+++ b/spec/clearbit/slack/attachments/person_spec.rb
@@ -23,4 +23,20 @@ describe Clearbit::Slack::Attachments::Person, '#as_json' do
       ]
       })
   end
+
+  it 'returns text when the bio field is null in the payload' do
+    person_data = parsed_fixture_data 'person.json'
+
+    # simluate the bio being null in the payload
+    person_data["bio"] = nil
+
+    person = Mash.new(person_data)
+
+    result = Clearbit::Slack::Attachments::Person.new(person).as_json
+
+    # the text value in the payload needs to not be nil
+    expect(result).to match(
+      text: a_value != nil
+    )
+  end
 end

--- a/spec/clearbit/slack/attachments/person_spec.rb
+++ b/spec/clearbit/slack/attachments/person_spec.rb
@@ -35,8 +35,8 @@ describe Clearbit::Slack::Attachments::Person, '#as_json' do
     result = Clearbit::Slack::Attachments::Person.new(person).as_json
 
     # the text value in the payload needs to not be nil
-    expect(result).to match(
-      text: a_value != nil
+    expect(result).not_to include(
+      text: a_nil_value
     )
   end
 end


### PR DESCRIPTION
Sometimes results are returned by the clearbit api where the person does not have a bio. This means that slack is unable to generate a payload to be sent. This provides a fallback value for when the bio is not returned so that slack links can also be generated.

This issue may be present on the company attachment as well but I have not seen a company come back with a null bio. If that is a possibility then we need to add a similar guard to that attachment payload.