### PR TITLE
Provide a fallback when description is not provided

### DIFF
--- a/lib/clearbit/slack/attachments/company.rb
+++ b/lib/clearbit/slack/attachments/company.rb
@@ -13,7 +13,7 @@ module Clearbit
           {
             author_name: company.name,
             author_icon: company.logo,
-            text: company.description,
+            text: company.description.to_s,
             color: color,
             fields: fields.compact
           }

--- a/spec/clearbit/slack/attachments/company_spec.rb
+++ b/spec/clearbit/slack/attachments/company_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
 describe Clearbit::Slack::Attachments::Company, '#as_json' do
+  let(:company_data) { parsed_fixture_data 'company.json' }
+  let(:company) { Mash.new(company_data) }
+  let(:result) { Clearbit::Slack::Attachments::Company.new(company).as_json }
+
   it 'returns a company attachment' do
-    company_data = parsed_fixture_data 'company.json'
-    company = Mash.new(company_data)
-
-    result = Clearbit::Slack::Attachments::Company.new(company).as_json
-
     expect(result).to include(
       {
         :author_name => "Clearbit",
@@ -61,6 +60,16 @@ describe Clearbit::Slack::Attachments::Company, '#as_json' do
           }
         ]
       }
+    )
+  end
+
+  it 'returns text when the description field is null in the payload' do
+    # simluate the bio being null in the payload
+    company_data["description"] = nil
+
+    # the text value in the payload needs to not be nil
+    expect(result).not_to include(
+      text: a_nil_value
     )
   end
 end

--- a/spec/clearbit/slack/attachments/company_spec.rb
+++ b/spec/clearbit/slack/attachments/company_spec.rb
@@ -64,7 +64,7 @@ describe Clearbit::Slack::Attachments::Company, '#as_json' do
   end
 
   it 'returns text when the description field is null in the payload' do
-    # simluate the bio being null in the payload
+    # simluate the description being null in the payload
     company_data["description"] = nil
 
     # the text value in the payload needs to not be nil


### PR DESCRIPTION
Following on from #25, this looks to also be an issue with company data coming
back from clearbit.