### PR TITLE
Update `slack-notifier` to `v2.3.2`

### DIFF
--- a/clearbit-slack.gemspec
+++ b/clearbit-slack.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'clearbit', '~> 0.2', '>= 0.2.2'
   spec.add_runtime_dependency 'maccman-mash', '~> 0.0', '>= 0.0.2'
-  spec.add_runtime_dependency 'slack-notifier', '~> 1.5.1', '>= 1.5.1'
+  spec.add_runtime_dependency 'slack-notifier', '~> 2.3.2', '>= 2.3.2'
 end

--- a/lib/clearbit/slack/notifier.rb
+++ b/lib/clearbit/slack/notifier.rb
@@ -25,8 +25,8 @@ module Clearbit
       def notifier
         ::Slack::Notifier.new(slack_url) do
           defaults(
-            channel: slack_channel,
-            icon_url: slack_icon
+            channel: @slack_channel,
+            icon_url: @slack_icon
           )
         end
       end

--- a/lib/clearbit/slack/notifier.rb
+++ b/lib/clearbit/slack/notifier.rb
@@ -23,11 +23,12 @@ module Clearbit
       end
 
       def notifier
-        ::Slack::Notifier.new(
-          slack_url,
-          channel:  slack_channel,
-          icon_url: slack_icon,
-        )
+        ::Slack::Notifier.new(slack_url) do
+          defaults(
+            channel: slack_channel,
+            icon_url: slack_icon
+          )
+        end
       end
 
       def attachments

--- a/lib/clearbit/slack/version.rb
+++ b/lib/clearbit/slack/version.rb
@@ -1,5 +1,5 @@
 module Clearbit
   module Slack
-    VERSION = '0.2.2'
+    VERSION = '0.2.3'
   end
 end

--- a/spec/clearbit/slack/notifier_spec.rb
+++ b/spec/clearbit/slack/notifier_spec.rb
@@ -21,12 +21,14 @@ describe Clearbit::Slack::Notifier do
     it 'returns the default values' do
       Clearbit::Slack::Notifier.new(params).ping
 
-      expect(Slack::Notifier).to have_received(:new).with(
-        'http://example', {
-          channel: '#test',
-          icon_url: nil,
-        }
-      )
+      expect(Slack::Notifier).to have_received(:new).with('http://example') { |&block|
+        expect(block).to be(
+          default(
+            channel: '#test',
+            icon_url: nil
+          )
+        )
+      }
 
       expect(notifier).to have_received(:ping).with('message', attachments: [{
         :fallback=>'alex@alexmaccaw.com - Alex Maccaw',


### PR DESCRIPTION
Per the request in https://github.com/clearbit/clearbit-slack/issues/28 here's a PR with the latest `slack-notifier` (`v2.3.2`) as a requirement. I've:
- updated the [`slack-notifier` gem requirements](https://github.com/stevenosloan/slack-notifier/blob/master/changelog.md#232)
- adjusted `Clearbit::Slack::Notifier#notifier` to use block syntax per [`slack-notifier`'s `v2.0` changes](https://github.com/stevenosloan/slack-notifier/blob/master/changelog.md#200)
- Fixed specs
- incremented the version of `clearbit-slack` to `v0.2.3` (wasn't sure whether this was required but it seemed unlikely that other changes were going to be rolled in before a new version).

I've not had the time to check this rigorously, and there might be config setting I've missed, so it will be worth someone more familiar with the `clearbit-slack` codebase going over this with a fine-toothed comb to be sure, but hopefully it's a starting point!