### PR TITLE
Remove the Bundler version restriction.

### DIFF
--- a/clearbit-slack.gemspec
+++ b/clearbit-slack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency 'bundler', '~> 1.9'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry', '~> 0.10', '>= 0.10.1'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.5', '>= 3.5.0'


### PR DESCRIPTION
Resolves four security alerts.

- Critical
  - https://github.com/clearbit/clearbit-slack/security/dependabot/5
- High
  - https://github.com/clearbit/clearbit-slack/security/dependabot/2
  - https://github.com/clearbit/clearbit-slack/security/dependabot/3
- Moderate
  - https://github.com/clearbit/clearbit-slack/security/dependabot/4
